### PR TITLE
User extensible whitelist

### DIFF
--- a/src/main/src/main/java/org/geoserver/config/util/SecureXStream.java
+++ b/src/main/src/main/java/org/geoserver/config/util/SecureXStream.java
@@ -18,6 +18,7 @@ import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.geoserver.platform.GeoServerExtensions;
 import org.geotools.util.NumberRange;
 import org.geotools.util.SimpleInternationalString;
 import org.geotools.util.Version;
@@ -103,6 +104,13 @@ public class SecureXStream extends XStream {
         allowTypes(new Class[] { TreeSet.class, SortedSet.class, Set.class, HashSet.class,
                 List.class, ArrayList.class, CopyOnWriteArrayList.class, Map.class, HashMap.class,
                 ConcurrentHashMap.class, });
+        
+        // Allow classes from user defined whitelist
+        String whitelistProp = GeoServerExtensions.getProperty("GEOSERVER_XSTREAM_WHITELIST");
+        if(whitelistProp != null) {
+            String[] wildcards = whitelistProp.split("\\s+|(\\s*;\\s*)");
+            this.allowTypesByWildcard(wildcards);
+        }
     }
 
 

--- a/src/main/src/test/java/org/geoserver/config/util/SecureXStreamTest.java
+++ b/src/main/src/test/java/org/geoserver/config/util/SecureXStreamTest.java
@@ -1,0 +1,62 @@
+/* (c) 2014 - 2015 Open Source Geospatial Foundation - all rights reserved
+ * (c) 2001 - 2013 OpenPlans
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+package org.geoserver.config.util;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.*;
+
+import org.geoserver.util.PropertyRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SecureXStreamTest {
+    
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    
+    @Rule
+    public PropertyRule whitelistProperty = PropertyRule.system("GEOSERVER_XSTREAM_WHITELIST");
+    
+    @Test
+    public void testPropertyCanAllow() throws Exception {
+        // Check that additional whitelist entries can be added via a system property.
+        
+        whitelistProperty.setValue("org.easymock.**");
+        
+        SecureXStream xs = new SecureXStream();
+        
+        // Check that a class in the package deserializes
+        Object o = xs.fromXML("<"+org.easymock.Capture.class.getCanonicalName()+" />");
+        assertThat(o, instanceOf(org.easymock.Capture.class));
+        
+        // Check that a class from elsewhere still causes an exception
+        exception.expect(com.thoughtworks.xstream.security.ForbiddenClassException.class);
+        xs.fromXML("<"+org.hamcrest.core.AllOf.class.getCanonicalName()+" />");
+    }
+    
+    @Test
+    public void testPropertyCanAllowMultiple() throws Exception {
+        // Check that additional whitelist entries can be added via a system property.
+        
+        whitelistProperty.setValue("org.easymock.**; org.junit.**");
+        
+        SecureXStream xs = new SecureXStream();
+        
+        // Check that a class in the first package deserializes
+        Object o1 = xs.fromXML("<"+org.easymock.Capture.class.getCanonicalName()+" />");
+        assertThat(o1, instanceOf(org.easymock.Capture.class));
+        
+        // Check that a class in the second package deserializes
+        Object o2 = xs.fromXML("<"+org.junit.rules.TestName.class.getCanonicalName()+" />");
+        assertThat(o2, instanceOf(org.junit.rules.TestName.class));
+        
+        // Check that a class from elsewhere still causes an exception
+        exception.expect(com.thoughtworks.xstream.security.ForbiddenClassException.class);
+        xs.fromXML("<"+org.hamcrest.core.AllOf.class.getCanonicalName()+" />");
+    }
+}

--- a/src/platform/src/test/java/org/geoserver/util/PropertyRule.java
+++ b/src/platform/src/test/java/org/geoserver/util/PropertyRule.java
@@ -4,7 +4,7 @@
  * application directory.
  */
 
-package org.geoserver.wfs.xml;
+package org.geoserver.util;
 
 import java.util.Properties;
 
@@ -14,7 +14,7 @@ import java.util.Properties;
  * @author Kevin Smith, Boundless
  *
  */
-class PropertyRule extends org.junit.rules.ExternalResource {
+public class PropertyRule extends org.junit.rules.ExternalResource {
     final Properties props;
     final String name;
     String oldValue;

--- a/src/wfs/pom.xml
+++ b/src/wfs/pom.xml
@@ -90,6 +90,13 @@
      <artifactId>hamcrest-library</artifactId>
      <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-platform</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/src/wfs/src/test/java/org/geoserver/wfs/xml/WFSURIHandlerTest.java
+++ b/src/wfs/src/test/java/org/geoserver/wfs/xml/WFSURIHandlerTest.java
@@ -24,6 +24,7 @@ import org.easymock.classextension.EasyMock;
 import org.eclipse.emf.common.util.URI;
 import org.geoserver.config.GeoServer;
 import org.geoserver.config.GeoServerInfo;
+import org.geoserver.util.PropertyRule;
 import org.geoserver.wfs.xml.WFSURIHandler.InitStrategy;
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
I've added a way for a user to add to the whitely via a property/parameter so that if we miss something or if someone is using a third party extension of some sort, there's a workaround available until GeoServer or the extension get updated.

Testing it has been problematic as I've started encountering some really strange unit test failures that appear to be related to GEOS-7032.  (see my post to devel)