### PR TITLE
[GEOS-7881] Include Marlin by default. Add support for OSX.

### DIFF
--- a/src/release/installer/mac/build.sh
+++ b/src/release/installer/mac/build.sh
@@ -9,8 +9,14 @@ function check_rc() {
   fi
 }
 
+# find marlin jar in zip file
+geoserver_zip=`find . -name "geoserver-*-bin.zip" | head -1`
+if [ ! -z "$geoserver_zip" ]; then
+  marlin_jar=`unzip -l -qq ${geoserver_zip} "*/WEB-INF/lib/marlin*.jar" | awk -F "/" '{print $NF}'`
+fi
+
 # build the app
-ant
+ant -Dmarlin_jar=${marlin_jar}
 check_rc $? "build app"
 
 APP_NAME=GeoServer.app

--- a/src/release/installer/mac/build.xml
+++ b/src/release/installer/mac/build.xml
@@ -110,6 +110,10 @@
       <option value="-Xmx512m"/>
       <option value="-Dapple.laf.useScreenMenuBar=true"/>
 
+      <!-- enable marlin renderer -->
+      <option value="-Xbootclasspath/a:$APP_ROOT/Contents/Java/webapps/geoserver/WEB-INF/lib/${marlin_jar}"/>
+      <option value="-Dsun.java2d.renderer=org.marlin.pisces.MarlinRenderingEngine"/>
+
       <!-- Workaround since the icon parameter for bundleapp doesn't work -->
       <option value="-Xdock:icon=Contents/Resources/GeoServer.icns"/>
 


### PR DESCRIPTION
I do not have much experience with OSX, so someone else should review and test my proposed changes. My test was done on a macOS Sierra virtual machine.