### PR TITLE
[GEOS-8351] JMS community module tests should depend explicitly on gs-wms module

### DIFF
--- a/src/community/jms-cluster/jms-geoserver/pom.xml
+++ b/src/community/jms-cluster/jms-geoserver/pom.xml
@@ -278,6 +278,13 @@
       <scope>test</scope>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.geoserver</groupId>
+      <artifactId>gs-wms</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsServicesTest.java
+++ b/src/community/jms-cluster/jms-geoserver/src/test/java/org/geoserver/cluster/JmsServicesTest.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 import static org.geoserver.cluster.JmsEventsListener.getMessagesForHandler;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**


### PR DESCRIPTION
Associated issue: https://osgeo-org.atlassian.net/browse/GEOS-8351

Fix build issue in JMS community module: https://github.com/geoserver/geoserver/pull/2599